### PR TITLE
Add session Api methods to match server and add global settings service

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,4 @@
-interface IConfig {
-  apiUrl: string;
-}
+import { IConfig } from './models/config/IConfig';
 
 export const Config: IConfig = {
    apiUrl : 'http://localhost:3000',

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,3 +1,7 @@
-export const Config = {
+interface IConfig {
+  apiUrl: string;
+}
+
+export const Config: IConfig = {
    apiUrl : 'http://localhost:3000',
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,0 +1,3 @@
+export const Config = {
+   apiUrl : 'http://localhost:3000',
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { HTTP_PROVIDERS } from '@angular/http';
+import { HttpModule } from '@angular/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -16,10 +16,11 @@ import { GlobalSettingsService } from './globalSettings.service';
   imports: [
     BrowserModule,
     FormsModule,
+    HttpModule,
     RouterModule.forRoot(CardAppRoutes)
   ],
   bootstrap: [AppComponent],
-  providers: [HTTP_PROVIDERS, GlobalSettingsService, SessionService]
+  providers: [GlobalSettingsService, SessionService]
 })
 export class AppModule {
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { HTTP_PROVIDERS } from '@angular/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -7,7 +8,8 @@ import { CardAppRoutes } from './app.routes';
 import { CardComponent } from './card';
 import { ClientArrivalViewComponent } from './client-arrival-view';
 import { SessionService } from './session.service';
-import { HTTP_PROVIDERS } from '@angular/http';
+import { GlobalSettingsService } from './globalSettings.service';
+
 
 @NgModule({
   declarations: [AppComponent, CardComponent, ClientArrivalViewComponent],
@@ -17,7 +19,7 @@ import { HTTP_PROVIDERS } from '@angular/http';
     RouterModule.forRoot(CardAppRoutes)
   ],
   bootstrap: [AppComponent],
-  providers: [HTTP_PROVIDERS, SessionService]
+  providers: [HTTP_PROVIDERS, GlobalSettingsService, SessionService]
 })
 export class AppModule {
 }

--- a/src/app/client-arrival/client-arrival.component.ts
+++ b/src/app/client-arrival/client-arrival.component.ts
@@ -24,7 +24,7 @@ export class ClientArrivalComponent implements OnInit {
     console.log(this.name);
     console.log(this.sessionId);
     this.sessionService
-      .checkSession(this.sessionId)
+      .get(this.sessionId)
       .subscribe((result) => {
         if (result.status === 200) {
           console.log(true);

--- a/src/app/globalSettings.service.spec.ts
+++ b/src/app/globalSettings.service.spec.ts
@@ -1,0 +1,16 @@
+// /* tslint:disable:no-unused-variable */
+
+// import { addProviders, async, inject } from '@angular/core/testing';
+// import { GlobalSettingsService } from './global-settings.service';
+
+// describe('Service: GlobalSettings', () => {
+//   beforeEach(() => {
+//     addProviders([GlobalSettingsService]);
+//   });
+
+//   it('should ...',
+//     inject([GlobalSettingsService],
+//       (service: GlobalSettingsService) => {
+//         expect(service).toBeTruthy();
+//       }));
+// });

--- a/src/app/globalSettings.service.ts
+++ b/src/app/globalSettings.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Config } from './app.config';
+
+@Injectable()
+export class GlobalSettingsService {
+  config = Config;
+
+  constructor() {
+  }
+
+  get() {
+    return this.config;
+  }
+}

--- a/src/app/globalSettings.service.ts
+++ b/src/app/globalSettings.service.ts
@@ -3,6 +3,7 @@ import { Config } from './app.config';
 
 @Injectable()
 export class GlobalSettingsService {
+
   config = Config;
 
   constructor() {
@@ -11,4 +12,5 @@ export class GlobalSettingsService {
   get() {
     return this.config;
   }
+
 }

--- a/src/app/models/config/IConfig.ts
+++ b/src/app/models/config/IConfig.ts
@@ -1,0 +1,3 @@
+export interface IConfig{
+  apiUrl: string;
+}

--- a/src/app/session.service.ts
+++ b/src/app/session.service.ts
@@ -1,15 +1,35 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Http } from '@angular/http';
+import { GlobalSettingsService } from './globalSettings.service';
 
 @Injectable()
 export class SessionService {
+  config;
+  constructor(private http: Http, private globalSettingsService: GlobalSettingsService ) {
+    this.config = globalSettingsService.get();
+  }
 
-  constructor(private http: Http) {}
+  create(){
+    return this.http.post(`${this.config.apiUrl}/sessions`, {});
+  }
 
-  checkSession(sessionId: string): Observable<any> {
-    let address = 'http://0.0.0.0:3000';
-    return this.http.get(`${address}?sessionId=${sessionId}`);
+  get(sessionId: string): Observable<any> {
+    return this.http.get(`${this.config.apiUrl}?sessionId=${sessionId}`);
+  }
+
+  end(sessionId: string){
+    return this.http.delete(`${this.config.apiUrl}/sessions/${sessionId}`);
+  }
+
+  setStatus(sessionId: string, state: string){
+    return this.http.put(`${this.config.apiUrl}/sessions/${sessionId}`, {'state': state});
+  }
+
+  addUser(sessionId: string, userId: string){
+    return this.http.put(`${this.config.apiUrl}/sessions/${sessionId}/user`, {
+      'userId': userId
+    });
   }
 
 }

--- a/src/app/session.service.ts
+++ b/src/app/session.service.ts
@@ -5,7 +5,9 @@ import { GlobalSettingsService } from './globalSettings.service';
 
 @Injectable()
 export class SessionService {
+
   config;
+
   constructor(private http: Http, private globalSettingsService: GlobalSettingsService ) {
     this.config = globalSettingsService.get();
   }

--- a/src/app/session.service.ts
+++ b/src/app/session.service.ts
@@ -26,7 +26,9 @@ export class SessionService {
   }
 
   setStatus(sessionId: string, state: string): Observable<any> {
-    return this.http.put(`${this.config.apiUrl}/sessions/${sessionId}`, {'state': state});
+    return this.http.put(`${this.config.apiUrl}/sessions/${sessionId}`, {
+      'state': state
+    });
   }
 
   addUser(sessionId: string, userId: string): Observable<any> {

--- a/src/app/session.service.ts
+++ b/src/app/session.service.ts
@@ -10,7 +10,7 @@ export class SessionService {
     this.config = globalSettingsService.get();
   }
 
-  create(){
+  create(): Observable<any> {
     return this.http.post(`${this.config.apiUrl}/sessions`, {});
   }
 
@@ -18,15 +18,15 @@ export class SessionService {
     return this.http.get(`${this.config.apiUrl}?sessionId=${sessionId}`);
   }
 
-  end(sessionId: string){
+  end(sessionId: string): Observable<any> {
     return this.http.delete(`${this.config.apiUrl}/sessions/${sessionId}`);
   }
 
-  setStatus(sessionId: string, state: string){
+  setStatus(sessionId: string, state: string): Observable<any> {
     return this.http.put(`${this.config.apiUrl}/sessions/${sessionId}`, {'state': state});
   }
 
-  addUser(sessionId: string, userId: string){
+  addUser(sessionId: string, userId: string): Observable<any> {
     return this.http.put(`${this.config.apiUrl}/sessions/${sessionId}/user`, {
       'userId': userId
     });

--- a/src/app/session.service.ts
+++ b/src/app/session.service.ts
@@ -2,11 +2,12 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Http } from '@angular/http';
 import { GlobalSettingsService } from './globalSettings.service';
+import { IConfig } from './models/config/iconfig';
 
 @Injectable()
 export class SessionService {
 
-  config;
+  config: IConfig;
 
   constructor(private http: Http, private globalSettingsService: GlobalSettingsService ) {
     this.config = globalSettingsService.get();


### PR DESCRIPTION
Add global settings service and match session service methods.

the server will need to be updated to match the call of the delete method for the service.  due to the session resource address mismatching a restful delete address. 

Instead of using opaque tokens, I've used a global setting service. The reason behind this is so we can mock this service when we add tests. Allowing us to create integration tests for the client.
Linked to : https://github.com/tsangste/ChaosSpankr.Home/issues/10